### PR TITLE
Bumped minimum required versions

### DIFF
--- a/class-wc-pd-core-compatibility.php
+++ b/class-wc-pd-core-compatibility.php
@@ -29,7 +29,7 @@ class WC_PD_Core_Compatibility {
 	}
 
 	/**
-	 * Returns true if the installed version of WooCommerce is 2.2 or greater.
+	 * Returns true if the installed version of WooCommerce is 8.2 or greater.
 	 *
 	 * @return boolean
 	 */

--- a/class-wc-pd-core-compatibility.php
+++ b/class-wc-pd-core-compatibility.php
@@ -29,66 +29,12 @@ class WC_PD_Core_Compatibility {
 	}
 
 	/**
-	 * Returns true if the installed version of WooCommerce is 2.7 or greater.
-	 *
-	 * @return boolean
-	 */
-	public static function is_wc_version_gte_2_7() {
-		return self::get_wc_version() && version_compare( self::get_wc_version(), '2.7', '>=' );
-	}
-
-	/**
-	 * Returns true if the installed version of WooCommerce is 2.6 or greater.
-	 *
-	 * @return boolean
-	 */
-	public static function is_wc_version_gte_2_6() {
-		return self::get_wc_version() && version_compare( self::get_wc_version(), '2.6', '>=' );
-	}
-
-	/**
-	 * Returns true if the installed version of WooCommerce is 2.5 or greater.
-	 *
-	 * @return boolean
-	 */
-	public static function is_wc_version_gte_2_5() {
-		return self::get_wc_version() && version_compare( self::get_wc_version(), '2.5', '>=' );
-	}
-
-	/**
-	 * Returns true if the installed version of WooCommerce is 2.4 or greater.
-	 *
-	 * @return boolean
-	 */
-	public static function is_wc_version_gte_2_4() {
-		return self::get_wc_version() && version_compare( self::get_wc_version(), '2.4', '>=' );
-	}
-
-	/**
-	 * Returns true if the installed version of WooCommerce is 2.3 or greater.
-	 *
-	 * @return boolean
-	 */
-	public static function is_wc_version_gte_2_3() {
-		return self::get_wc_version() && version_compare( self::get_wc_version(), '2.3', '>=' );
-	}
-
-	/**
 	 * Returns true if the installed version of WooCommerce is 2.2 or greater.
 	 *
 	 * @return boolean
 	 */
-	public static function is_wc_version_gte_2_2() {
-		return self::get_wc_version() && version_compare( self::get_wc_version(), '2.2', '>=' );
-	}
-
-	/**
-	 * Returns true if the installed version of WooCommerce is less than 2.2.
-	 *
-	 * @return boolean
-	 */
-	public static function is_wc_version_lt_2_2() {
-		return self::get_wc_version() && version_compare( self::get_wc_version(), '2.2', '<' );
+	public static function is_wc_version_gte_8_2() {
+		return self::get_wc_version() && version_compare( self::get_wc_version(), '8.2', '>=' );
 	}
 
 	/**
@@ -99,65 +45,5 @@ class WC_PD_Core_Compatibility {
 	 */
 	public static function is_wc_version_gt( $version ) {
 		return self::get_wc_version() && version_compare( self::get_wc_version(), $version, '>' );
-	}
-
-	/**
-	 * Get the WC Product instance for a given product ID or post.
-	 *
-	 * get_product() is soft-deprecated in WC 2.2
-	 *
-	 * @param  bool|int|string|WP_Post  $the_product
-	 * @param  array                    $args
-	 * @return WC_Product
-	 */
-	public static function wc_get_product( $the_product = false, $args = array() ) {
-		if ( self::is_wc_version_gte_2_2() ) {
-			return wc_get_product( $the_product, $args );
-		} else {
-
-			return get_product( $the_product, $args );
-		}
-	}
-
-	/**
-	 * Display a WooCommerce help tip.
-	 *
-	 * @param  string  $tip
-	 * @return string
-	 */
-	public static function wc_help_tip( $tip ) {
-		if ( self::is_wc_version_gte_2_5() ) {
-			return wc_help_tip( $tip );
-		} else {
-			return '<img class="help_tip woocommerce-help-tip" data-tip="' . $tip . '" src="' . WC()->plugin_url() . '/assets/images/help.png" />';
-		}
-	}
-
-	/**
-	 * Back-compat wrapper for 'get_parent_id'.
-	 *
-	 * @param  WC_Product  $product
-	 * @return mixed
-	 */
-	public static function get_parent_id( $product ) {
-		if ( self::is_wc_version_gte_2_7() ) {
-			return $product->get_parent_id();
-		} else {
-			return $product->is_type( 'variation' ) ? absint( $product->id ) : 0;
-		}
-	}
-
-	/**
-	 * Back-compat wrapper for 'get_id'.
-	 *
-	 * @param  WC_Product  $product
-	 * @return mixed
-	 */
-	public static function get_id( $product ) {
-		if ( self::is_wc_version_gte_2_7() ) {
-			return $product->get_id();
-		} else {
-			return $product->is_type( 'variation' ) ? absint( $product->variation_id ) : absint( $product->id );
-		}
 	}
 }

--- a/class-wc-pd-helpers.php
+++ b/class-wc-pd-helpers.php
@@ -16,7 +16,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  * Helper functions.
  *
  * @class    WC_PD_Helpers
- * @version  1.2.0
+ * @version  2.0.0
  */
 class WC_PD_Helpers {
 
@@ -62,7 +62,7 @@ class WC_PD_Helpers {
 
 				$part_to_merge     = self::get_part_to_merge_expression( $loop, count( $products ), $relationship );
 				$product_permalink = $product->is_visible() ? $product->get_permalink() : '';
-				$product_title     = WC_PD_Core_Compatibility::is_wc_version_gte_2_7() ? $product->get_name() : $product->get_title();
+				$product_title     = $product->get_name();
 
 				if ( $product_permalink ) {
 					$part_to_merge = sprintf( $part_to_merge, sprintf( '&quot;<a href="%1$s">%2$s</a>&quot;', esc_url( $product_permalink ), $product_title ) );
@@ -147,21 +147,7 @@ class WC_PD_Helpers {
 			return false;
 		}
 
-		if ( WC_PD_Core_Compatibility::is_wc_version_gte_2_7() ) {
-			return $product->get_formatted_name();
-		}
-
-		$title = $title ? $title : $product->get_title();
-		$sku   = $product->get_sku();
-		$id    = WC_PD_Core_Compatibility::get_id( $product );
-
-		if ( $sku ) {
-			$identifier = $sku;
-		} else {
-			$identifier = '#' . $id;
-		}
-
-		return self::format_product_title( $title, $identifier, '', WC_PD_Core_Compatibility::is_wc_version_gte_2_7() );
+		return $product->get_formatted_name();
 	}
 
 	/**

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
 		"url": "https://github.com/somewherewarm/woocommerce-product-dependencies.git"
 	},
 	"license": "GPL-3.0+",
-	"version": "1.2.8",
+	"version": "2.0.0",
 	"main": "Gruntfile.js",
 	"devDependencies": {
 		"grunt": "~1.0.1",

--- a/readme.txt
+++ b/readme.txt
@@ -1,6 +1,6 @@
 === WooCommerce Product Dependencies ===
 
-Contributors: SomewhereWarm
+Contributors: automattic, woocommerce, SomewhereWarm
 Tags: woocommerce, products, dependencies, prerequisite, restrict
 Requires at least: 6.2
 Tested up to: 6.6

--- a/readme.txt
+++ b/readme.txt
@@ -2,11 +2,11 @@
 
 Contributors: SomewhereWarm, franticpsyx, jasonkytros
 Tags: woocommerce, products, dependencies, prerequisite, required, access, restrict, ownership, purchase, together
-Requires at least: 3.8
-Tested up to: 6.3
-WC requires at least: 2.2
-WC tested up to: 8.0
-Stable tag: 1.2.8
+Requires at least: 6.2
+Tested up to: 6.6
+WC requires at least: 8.2
+WC tested up to: 9.1
+Stable tag: 2.0.0
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -77,6 +77,11 @@ The plugin allows you to select between 3 different dependency types:
 
 
 == Changelog ==
+
+= 2.0.0 =
+* Important - New: PHP 7.4+ is now required.
+* Important - New: WooCommerce 8.2+ is now required.
+* Important - New: WordPress 6.2+ is now required.
 
 = 1.2.8 =
 * Feature - Declared compatibility with the new High-Performance Order Tables.

--- a/readme.txt
+++ b/readme.txt
@@ -1,7 +1,7 @@
 === WooCommerce Product Dependencies ===
 
-Contributors: SomewhereWarm, franticpsyx, jasonkytros
-Tags: woocommerce, products, dependencies, prerequisite, required, access, restrict, ownership, purchase, together
+Contributors: SomewhereWarm
+Tags: woocommerce, products, dependencies, prerequisite, restrict
 Requires at least: 6.2
 Tested up to: 6.6
 WC requires at least: 8.2


### PR DESCRIPTION
### Description

This PR bumps the minimum required:
- PHP version to 7.4,
- WordPress version to 6.2 and;
- WooCommerce version to 8.2.